### PR TITLE
Fix: Correct SyntaxError in index3.html

### DIFF
--- a/index3.html
+++ b/index3.html
@@ -192,8 +192,9 @@
                     player.position.x -= playerSpeed;
                 }
                 if (keyboard['ArrowRight'] || keyboard['KeyD']) {
-                player.position.x += playerSpeed;
-            }
+                   player.position.x += playerSpeed;
+                } // This brace closes the ArrowRight/KeyD if
+            } // THIS IS THE ADDED CLOSING BRACE
 
             // Update Projectile Positions & Collision Detection
             for (let i = projectiles.length - 1; i >= 0; i--) {


### PR DESCRIPTION
A `SyntaxError: Unexpected end of input` was occurring in `index3.html` due to a missing closing curly brace.

This commit adds the missing `}` to the `if (!isGameOver)` block within the `animate()` function, specifically after the player movement control logic. This resolves the parsing error.

A brief review of the file was conducted after the fix, and no other obvious errors were identified.