### PR TITLE
Fix: Correct 'A' key strafe and stabilize camera

### DIFF
--- a/index4.html
+++ b/index4.html
@@ -102,8 +102,9 @@
         player.add(playerHead);
 
         // Attach camera to player group
-        player.add(camera);
+        // player.add(camera); // Decouple camera from player group
         camera.position.set(0, 2, 5); // Eyes roughly at y=1.2 relative to player group's origin (feet)
+        camera.lookAt(player.position.clone().add(new THREE.Vector3(0, 1.0, 0))); // Initial lookAt
 
         // Player Movement Variables
         const playerSpeed = 0.1;
@@ -178,11 +179,20 @@
                 euler.y = cameraOrbitYaw;
                 camera.quaternion.setFromEuler(euler);
 
-                const offset = new THREE.Vector3(0, 0, 5); // Distance from player
-                offset.applyQuaternion(camera.quaternion); // Rotate offset by camera's new orientation
-                camera.position.copy(player.position).add(offset);
-                camera.position.y += 2; // Elevate camera a bit more consistently
-                camera.lookAt(player.position.clone().add(new THREE.Vector3(0, 1, 0))); // Look at player's head area.
+                // Player's head position or a point slightly above the player's main position
+                const targetPosition = player.position.clone().add(new THREE.Vector3(0, 1.0, 0)); // Adjust Y offset as needed for what to look at
+
+                // Calculate desired offset from the player (e.g., behind and slightly above)
+                const desiredOffset = new THREE.Vector3(0, 1.5, 5); // (x, y, z offset from target) - y is height, z is distance
+
+                // Rotate this offset by the camera's current quaternion (which includes mouse look)
+                const rotatedOffset = desiredOffset.clone().applyQuaternion(camera.quaternion);
+
+                // Set the camera's position
+                camera.position.copy(targetPosition).add(rotatedOffset);
+
+                // Ensure camera looks at the target position (e.g., player's head area)
+                camera.lookAt(targetPosition);
             }
         }
 
@@ -276,7 +286,7 @@
                     moveDirection.sub(forward); // Move backward
                 }
                 if (keyboard['ArrowLeft'] || keyboard['KeyA']) {
-                    moveDirection.sub(right); // Strafe left
+                    moveDirection.add(right); // Strafe left
                 }
                 if (keyboard['ArrowRight'] || keyboard['KeyD']) {
                    moveDirection.sub(right); // Strafe right


### PR DESCRIPTION
- I modified the player movement logic so you correctly strafe left when the 'A' key is pressed. The `moveDirection` now correctly adds the `right` vector for leftward movement.
- I refactored the camera controls for improved stability in third-person view:
    - I decoupled the camera from the player's group to simplify transformations.
    - I implemented a standard follow-camera mechanism where the camera's position is calculated based on an offset from the player, rotated by mouse input.
    - I ensured `camera.lookAt` consistently targets the player.
    - I adjusted the initial camera setup to align with the new logic. This should resolve the issue of the 'A' key moving right and the previously reported odd camera behavior.