### PR TITLE
Fix: Corrected mouseHasMoved flag reset logic

### DIFF
--- a/index4.html
+++ b/index4.html
@@ -567,8 +567,8 @@
                 if (oldVisibility !== previewBlock.visible) {
                     console.log("previewBlock.visible changed from", oldVisibility, "to", previewBlock.visible, "(no intersection)");
                 }
-                mouseHasMoved = false; // Reset the flag after updating
             }
+            mouseHasMoved = false; // CORRECT PLACEMENT: Reset flag after all conditional logic for preview block
 
             // Camera positioning logic
             // Player's head position or a point slightly above the player's main position


### PR DESCRIPTION
This commit addresses a persistent issue where the preview block would still reset its position or visibility even when the mouse was stationary.

The root cause was that the `mouseHasMoved` flag was not being reset correctly in all cases within the `animate` function. Specifically, if a raycast resulted in no intersections, the flag might not have been reset, causing the preview block logic to run in subsequent frames without actual mouse movement.

The `mouseHasMoved = false;` line has been moved to the end of the `if (mouseHasMoved)` block, ensuring it is always reset after the preview block's state is updated due to mouse input. This prevents the block from changing position or visibility when the mouse is still.